### PR TITLE
handle tauri v2 config schema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,11 @@ function tauriVersion(
     'utf-8'
   )
   const confObj = JSON.parse(confContent)
-  confObj.package.version = ver
+  if (confObj.package) { // v1
+    confObj.package.version = ver
+  } else { // v2
+    confObj.version = ver
+  }
   writeFileSync(
     join(getPath(tauriPath), 'tauri.conf.json'),
     JSON.stringify(confObj, null, 2)


### PR DESCRIPTION
v2 of tauri has the version field on the root of the config.

this change will handle both versions.

I couldn't find tests for checking tauri.conf.json files, so this PR doesn't have tests unfortunately 😅.